### PR TITLE
参拝投稿の詳細ページ実装 

### DIFF
--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -1,7 +1,7 @@
 class WorshipsController < ApplicationController
   before_action :authenticate_user!, except: :index
   def index
-    @worships = Worship.order(id: :asc)
+    @worships = Worship.all.includes(:user).order(:created_at)
   end
 
   def show
@@ -14,7 +14,7 @@ class WorshipsController < ApplicationController
 
   def create
     current_user.worships.create!(worship_params)
-    redirect_to worships_path
+    redirect_to worship
   end
 
   def edit; end

--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -4,7 +4,9 @@ class WorshipsController < ApplicationController
     @worships = Worship.all
   end
 
-  def show; end
+  def show
+    @worship = Worship.find(params[:id])
+  end
 
   def new
     @worship = Worship.new

--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -14,6 +14,7 @@ class WorshipsController < ApplicationController
 
   def create
     current_user.worships.create!(worship_params)
+    redirect_to worships_path
   end
 
   def edit; end

--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -1,7 +1,7 @@
 class WorshipsController < ApplicationController
   before_action :authenticate_user!, except: :index
   def index
-    @worships = Worship.all
+    @worships = Worship.order(id: :asc)
   end
 
   def show

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -5,6 +5,11 @@
     <p><%= worship.title %></p>
     <p><%= worship.place %></p>
     <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
+    <p>
+      <%= link_to "詳細", worship %>
+      <%= link_to "編集", edit_worship_path(worship) %>
+      <%= link_to "削除", worship_path(worship), method: :delete, data: { confirm: "削除しますか?" } %>
+    </p>
     <hr>
   <% end %>
 <% else %>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -4,8 +4,6 @@
     <p><%= worship.category %></p>
     <p><%= worship.title %></p>
     <p><%= worship.place %></p>
-    <p><%= worship.date %></p>
-    <p><%= worship.content %></p>
     <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
     <hr>
   <% end %>

--- a/app/views/worships/show.html.erb
+++ b/app/views/worships/show.html.erb
@@ -1,14 +1,13 @@
 <h1>参拝記事一覧</h1>
-<% if user_signed_in? %>
-  <% @worships.each do |worship| %>
-    <p><%= @worship.category %></p>
-    <p><%= @worship.title %></p>
-    <p><%= @worship.place %></p>
-    <p><%= @worship.date %></p>
-    <p><%= @worship.content %></p>
-    <p><%= @worship.user_name.present? ? @worship.user_name : "会員No.#{@worship.user.id}" %></p>
-    <hr>
-  <% end %>
-<% else %>
-  <p>ログインしてください</p>
-<% end %>
+<p><%= @worship.category %></p>
+<p><%= @worship.title %></p>
+<p><%= @worship.place %></p>
+<p><%= @worship.date %></p>
+<p><%= @worship.content %></p>
+<p><%= @worship.user_name.present? ? @worship.user_name : "会員No.#{@worship.user.id}" %></p>
+<p>
+  <%= link_to "編集", edit_worship_path(@worship) %>
+  <%= link_to "削除", worship_path(@worship), method: :delete, data: { confirm: "削除しますか?" } %>
+</p>
+<hr>
+<p><%= link_to "投稿一覧へ", worships_path %></p>

--- a/app/views/worships/show.html.erb
+++ b/app/views/worships/show.html.erb
@@ -1,2 +1,14 @@
-<h1>Worships#show</h1>
-<p>Find me in app/views/worships/show.html.erb</p>
+<h1>参拝記事一覧</h1>
+<% if user_signed_in? %>
+  <% @worships.each do |worship| %>
+    <p><%= @worship.category %></p>
+    <p><%= @worship.title %></p>
+    <p><%= @worship.place %></p>
+    <p><%= @worship.date %></p>
+    <p><%= @worship.content %></p>
+    <p><%= @worship.user_name.present? ? @worship.user_name : "会員No.#{@worship.user.id}" %></p>
+    <hr>
+  <% end %>
+<% else %>
+  <p>ログインしてください</p>
+<% end %>


### PR DESCRIPTION
close #20 

## 実装内容
#15   [参拝記事CRUD処理の実装]完了後に行う

- コントローラ
  - worshipsコントローラの showアクション に記述
  - indexアクションにid順で並べる処理を追記

- ビュー
  - `show.html.erb`に詳細情報を記載
  - `index.html.erb`の各投稿に詳細ページへのリンクを作成

## チェックリスト

- [x] 各動作の確認
- [x] rubocop -a を実行
- [x] bundle exec rails_best_practices .  を実行 