### PR TITLE
参拝投稿の削除機能の実装

### DIFF
--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -1,5 +1,6 @@
 class WorshipsController < ApplicationController
   before_action :authenticate_user!, except: :index
+  before_action :set_worship, only: %i[edit update destroy]
   def index
     @worships = Worship.all.includes(:user).order(:created_at)
   end
@@ -21,11 +22,18 @@ class WorshipsController < ApplicationController
 
   def update; end
 
-  def destroy; end
-end
+  def destroy
+    @worship.destroy!
+    redirect_to @worship
+  end
 
-private
+  private
 
-def worship_params
-  params.require(:worship).permit(:category, :title, :place, :date, :content)
+  def worship_params
+    params.require(:worship).permit(:category, :title, :place, :date, :content)
+  end
+
+  def set_worship
+    @worship = current_user.worships.find(params[:id])
+  end
 end

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -7,8 +7,6 @@
     <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
     <p>
       <%= link_to "詳細", worship %>
-      <%= link_to "編集", edit_worship_path(worship) %>
-      <%= link_to "削除", worship_path(worship), method: :delete, data: { confirm: "削除しますか?" } %>
     </p>
     <hr>
   <% end %>

--- a/app/views/worships/show.html.erb
+++ b/app/views/worships/show.html.erb
@@ -5,9 +5,11 @@
 <p><%= @worship.date %></p>
 <p><%= @worship.content %></p>
 <p><%= @worship.user_name.present? ? @worship.user_name : "会員No.#{@worship.user.id}" %></p>
-<p>
-  <%= link_to "編集", edit_worship_path(@worship) %>
-  <%= link_to "削除", worship_path(@worship), method: :delete, data: { confirm: "削除しますか?" } %>
-</p>
+<% if current_user.id == @worship.user_id %>
+  <p>
+    <%= link_to "編集", edit_worship_path(@worship) %>
+    <%= link_to "削除", worship_path(@worship), method: :delete, data: { confirm: "削除しますか?" } %>
+  </p>
+<% end %>
 <hr>
 <p><%= link_to "投稿一覧へ", worships_path %></p>


### PR DESCRIPTION
close #21 

## 実装内容
#15,  #20 完了後に行う

- コントローラ
  - destroyアクションを追記
  - before_action を追記

- ビュー
  - `show.html.erb`に自分のメッセージのみ「編集」「削除」のリンクが表示されるように修正

## チェックリスト

- [x] 自分の投稿のみ編集・削除が可能
- [x] rubocop -a を実行
- [x] bundle exec rails_best_practices .  を実行 