### PR TITLE
Bootstrap導入

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+
+@import "bootstrap/scss/bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,36 @@
  */
 
 @import "bootstrap/scss/bootstrap";
+
+// 参拝 御朱印 カードデザイン
+.card {
+  background: #fff;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px #ccc;
+}
+.card-img {
+  border-radius: 5px 5px 0 0;
+  max-width: 100%;
+  height: auto;
+}
+.card-content {
+  padding: 20px;
+}
+.card-text {
+  color: #777;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.card-link {
+  text-align: center;
+  border-top: 1px solid #eee;
+  padding: 20px;
+}
+.card-link a {
+  text-decoration: none;
+  color: #0bd;
+  margin: 0 10px;
+}
+.card-link a:hover {
+  color: #0090aa;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -2,6 +2,9 @@
 // present in this directory. You're encouraged to place your actual application logic in
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets
 
 import Rails from '@rails/ujs';
 import Turbolinks from 'turbolinks';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,11 +3,12 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
+import Rails from '@rails/ujs';
+import Turbolinks from 'turbolinks';
+import * as ActiveStorage from '@rails/activestorage';
+import 'channels';
+import 'bootstrap/dist/js/bootstrap';
 
-Rails.start()
-Turbolinks.start()
-ActiveStorage.start()
+Rails.start();
+Turbolinks.start();
+ActiveStorage.start();

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -17,9 +17,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   # サムネイル画像を表示
-  version :thumb do
-    process resize_to_fit: [100, 100]
-  end
+  # version :thumb do
+  #   process resize_to_fit: [300, 180]
+  # end
 
   # 画像サイズ
   # 画像が大きい場合のみリサイズ

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,1 +1,2 @@
 <h1>top page</h1>
+<button type="button" class="btn btn-primary">Primary</button>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,2 +1,1 @@
 <h1>top page</h1>
-<button type="button" class="btn btn-primary">Primary</button>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -1,21 +1,24 @@
 <h1>参拝記事一覧</h1>
-<div class="row" >
-  <% if user_signed_in? %>
-    <% @worships.each do |worship| %>
-      <div class="col-md-3">
-        <div class="card">
-          <% if worship.images? %>
-            <p><%= image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
-          <% end %>
-          <p><%= worship.category %></p>
-          <p><%= worship.title %></p>
-          <p><%= worship.place %></p>
-          <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
-          <p　><%= link_to "詳細", worship, class: "btn btn-primary" %></p>
-      　</div>
-    　</div>
-    <% end %>
-  <% else %>
-      <p>ログインしてください</p>
-  <% end %>
+<div class="texts-wrapper">
+  <div class="contents-title text-center">
+    <div class="row" >
+      <% if user_signed_in? %>
+        <% @worships.each do |worship| %>
+          <div class="col-4 col-md-3 col-lg-2">
+            <div class="card">
+              <% if worship.images? %>
+                <p><%= link_to image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
+              <% end %>
+              <p><%= worship.category %> | <%= worship.place %></p>
+              <p><%= worship.title %></p>
+              <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
+              <p　><%= link_to "詳細", worship, class: "btn btn-primary" %></p>
+          　</div>
+        　</div>
+        <% end %>
+      <% else %>
+          <p>ログインしてください</p>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -5,14 +5,14 @@
       <% if user_signed_in? %>
         <% @worships.each do |worship| %>
           <div class="col-4 col-md-3 col-lg-2">
+          <a href="/worships/<%= worship.id %>">
             <div class="card">
               <% if worship.images? %>
-                <p><%= link_to image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
+                <p><%= image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
               <% end %>
               <p><%= worship.category %> | <%= worship.place %></p>
               <p><%= worship.title %></p>
               <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
-              <p　><%= link_to "詳細", worship, class: "btn btn-primary" %></p>
           　</div>
         　</div>
         <% end %>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -1,16 +1,21 @@
 <h1>参拝記事一覧</h1>
-<% if user_signed_in? %>
-  <% @worships.each do |worship| %>
-    <p><%= worship.category %></p>
-    <p><%= worship.title %></p>
-    <p><%= worship.place %></p>
-    <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
-    <% if worship.images? %>
-      <p><%= image_tag worship.images[0].thumb.to_s %></p>
+<div class="row" >
+  <% if user_signed_in? %>
+    <% @worships.each do |worship| %>
+      <div class="col-md-3">
+        <div class="card">
+          <% if worship.images? %>
+            <p><%= image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
+          <% end %>
+          <p><%= worship.category %></p>
+          <p><%= worship.title %></p>
+          <p><%= worship.place %></p>
+          <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
+          <p　><%= link_to "詳細", worship, class: "btn btn-primary" %></p>
+      　</div>
+    　</div>
     <% end %>
-    <p><%= link_to "詳細", worship %></p>
-    <hr>
+  <% else %>
+      <p>ログインしてください</p>
   <% end %>
-<% else %>
-  <p>ログインしてください</p>
-<% end %>
+</div>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,12 @@
-const { environment } = require('@rails/webpacker')
+const { environment } = require('@rails/webpacker');
 
-module.exports = environment
+const webpack = require('webpack');
+environment.plugins.append(
+  'Provide',
+  new webpack.ProvidePlugin({
+    $: 'jquery',
+    jQuery: 'jquery',
+  })
+);
+
+module.exports = environment;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.0",
+    "bootstrap": "~4.5.1",
+    "jquery": "^3.6.0",
+    "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@~4.5.1:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.3.tgz#c6a72b355aaf323920be800246a6e4ef30997fe6"
+  integrity sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3760,6 +3765,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4718,6 +4728,11 @@ pnp-webpack-plugin@^1.6.4:
   integrity sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==
   dependencies:
     ts-pnp "^1.1.6"
+
+popper.js@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
 
 portfinder@^1.0.26:
   version "1.0.28"


### PR DESCRIPTION
close #24 

## 実装内容

- Bootstrap 4 をインストール
  - yarn add bootstrap@~4.5.1 jquery popper.js

- JavaScript のファイルを読み込めるようにする
  - `app/javascript/packs/application.js` に `import "bootstrap/dist/js/bootstrap"`を追記

-  jQuery を Bootstrap 以外でも使用できるように，次のファイルに以下を追記。
```ruby
config/webpack/environment.js
const { environment } = require('@rails/webpacker')

// ***** 以下を追加 *****
const webpack = require('webpack')
environment.plugins.append('Provide', new webpack.ProvidePlugin({
    $: 'jquery',
    jQuery: 'jquery'
}))
// ***** 以上を追加 *****

module.exports = environment
```

- app/assets/stylesheets/application.css の拡張子 css を scss に変更
- @import "bootstrap/scss/bootstrap"; を追加
```ruby
app/assets/stylesheets/application.scss
/*
 *= require_tree .
 *= require_self
 */

@import "bootstrap/scss/bootstrap";
```

## チェックリスト
- [x] rubocop -a を実行
- [x] bundle exec rails_best_practices .  を実行 
- [x] お試しで参拝記事一覧にBootstrapを適用