### PR TITLE
御朱印帳の画像投稿機能

### DIFF
--- a/app/controllers/seals_controller.rb
+++ b/app/controllers/seals_controller.rb
@@ -34,7 +34,7 @@ class SealsController < ApplicationController
   private
 
   def seal_params
-    params.require(:seal).permit(:category, :title, :place, :date)
+    params.require(:seal).permit(:category, :title, :place, :date, { images: [] })
   end
 
   def set_seal

--- a/app/models/seal.rb
+++ b/app/models/seal.rb
@@ -1,4 +1,7 @@
 class Seal < ApplicationRecord
   belongs_to :user
+
+  mount_uploaders :images, SealImageUploader
+
   delegate :name, to: :user, prefix: true, allow_nil: true
 end

--- a/app/models/worship.rb
+++ b/app/models/worship.rb
@@ -1,9 +1,9 @@
 class Worship < ApplicationRecord
-  mount_uploaders :images, ImageUploader
-
   belongs_to :user
 
   has_many :comments, dependent: :destroy
+
+  mount_uploaders :images, ImageUploader
 
   delegate :name, to: :user, prefix: true, allow_nil: true
 end

--- a/app/uploaders/seal_image_uploader.rb
+++ b/app/uploaders/seal_image_uploader.rb
@@ -1,19 +1,14 @@
 class SealImageUploader < CarrierWave::Uploader::Base
-  # Include RMagick or MiniMagick support:
-  # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
-  # Choose what kind of storage to use for this uploader:
   storage :file
   # storage :fog
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # デフォルト画像の表示
   # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:
   #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
@@ -21,27 +16,48 @@ class SealImageUploader < CarrierWave::Uploader::Base
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
 
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
+  # サムネイル画像を表示
   # version :thumb do
-  #   process resize_to_fit: [50, 50]
+  #   process resize_to_fit: [300, 180]
   # end
 
-  # Add an allowlist of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  # 画像サイズ
+  # 画像が大きい場合のみリサイズ
+  # process resize_to_limit: [400, 400]
 
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # 画像が小さい場合もリサイズ
+  # process resize_to_fit: [1000, 1000]
+
+  # 指定サイズで切り抜く
+  process resize_to_fill: [200, 200, "center"]
+
+  # ファイル形式の制限
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  # ファイルサイズの上限
+  def size_range
+    0..(10.megabytes)
+  end
+
+  # jpg に変換
+  process convert: "jpg"
+
+  # ファイル名の拡張子を jpg に変更
+  def filename
+    "#{super.chomp(File.extname(super))}.jpg" if original_filename.present?
+  end
+
+  # ファイル名をランダムに変更
   # def filename
-  #   "something.jpg" if original_filename
+  #   "#{secure_token}.#{file.extension}" if original_filename.present?
+  # end
+
+  # protected
+
+  # def secure_token
+  #   var = :"@#{mounted_as}_secure_token"
+  #   model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
   # end
 end

--- a/app/uploaders/seal_image_uploader.rb
+++ b/app/uploaders/seal_image_uploader.rb
@@ -1,0 +1,47 @@
+class SealImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/seals/_form.html.erb
+++ b/app/views/seals/_form.html.erb
@@ -8,7 +8,7 @@
   <p><%= f.label :date, "参拝日" %></p>
   <p><%= f.date_field :date %></p>
   <p>
-    <%= f.file_field :images,  multiple: true %>
+    <%= f.file_field :images, multiple: true, accept: "images/png,images/jpeg,images/gif" %>
   </p>
   <p><%= f.submit button_value %></p>
   <p><%= link_to "戻る", :back %></p>

--- a/app/views/seals/_form.html.erb
+++ b/app/views/seals/_form.html.erb
@@ -9,6 +9,13 @@
   <p><%= f.date_field :date %></p>
   <p>
     <%= f.file_field :images, multiple: true, accept: "images/png,images/jpeg,images/gif" %>
+    <%= f.hidden_field :images_cache %>
+  </p>
+  <p>
+    <label>
+      <%= f.check_box :remove_images %>
+      画像を削除する
+    </label>
   </p>
   <p><%= f.submit button_value %></p>
   <p><%= link_to "戻る", :back %></p>

--- a/app/views/seals/_form.html.erb
+++ b/app/views/seals/_form.html.erb
@@ -7,6 +7,9 @@
   <p><%= f.text_field :place %></p>
   <p><%= f.label :date, "参拝日" %></p>
   <p><%= f.date_field :date %></p>
+  <p>
+    <%= f.file_field :images,  multiple: true %>
+  </p>
   <p><%= f.submit button_value %></p>
   <p><%= link_to "戻る", :back %></p>
 <% end %>

--- a/app/views/seals/index.html.erb
+++ b/app/views/seals/index.html.erb
@@ -7,6 +7,9 @@
           <div class="col-4 col-md-3 col-lg-2">
             <a href="/seals/<%= seal.id %>">
               <div class="card">
+                <% if seal.images? %>
+                  <p><%= image_tag seal.images[0].to_s, class: 'card-img-top' %></p>
+                <% end %>
                 <p><%= seal.category %> | <%= seal.place %></p>
                 <p><%= seal.title %></p>
                 <p><%= seal.user_name.present? ? seal.user_name : "会員No.#{seal.user.id}" %></p>

--- a/app/views/seals/show.html.erb
+++ b/app/views/seals/show.html.erb
@@ -4,6 +4,11 @@
 <p>場所 : <%= @seal.place %></p>
 <p>参拝日 : <%= @seal.date %></p>
 <%= @seal.user_name.present? ? @seal.user_name : "会員No.#{@seal.user.id}" %></p>
+<% if @seal.images? %>
+  <% @seal.images.each do |image|  %>
+    <%= image_tag image.to_s %>
+  <% end %>
+<% end %>
 <% if current_user.id == @seal.user_id %>
   <p>
     <%= link_to "編集", edit_seal_path(@seal) %>

--- a/app/views/seals/show.html.erb
+++ b/app/views/seals/show.html.erb
@@ -1,14 +1,14 @@
 <h1>御朱印帳 詳細</h1>
-<p><%= @seal.category %></p>
-<p><%= @seal.title %></p>
-<p>場所 : <%= @seal.place %></p>
-<p>参拝日 : <%= @seal.date %></p>
-<%= @seal.user_name.present? ? @seal.user_name : "会員No.#{@seal.user.id}" %></p>
 <% if @seal.images? %>
   <% @seal.images.each do |image|  %>
     <%= image_tag image.to_s %>
   <% end %>
 <% end %>
+<p><%= @seal.category %></p>
+<p><%= @seal.title %></p>
+<p>場所 : <%= @seal.place %></p>
+<p>参拝日 : <%= @seal.date %></p>
+<%= @seal.user_name.present? ? @seal.user_name : "会員No.#{@seal.user.id}" %></p>
 <% if current_user.id == @seal.user_id %>
   <p>
     <%= link_to "編集", edit_seal_path(@seal) %>

--- a/db/migrate/20210920092352_rename_image_column_to_seal.rb
+++ b/db/migrate/20210920092352_rename_image_column_to_seal.rb
@@ -1,0 +1,5 @@
+class RenameImageColumnToSeal < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :seals, :image, :images
+  end
+end

--- a/db/migrate/20210920092648_change_datatype_images_of_seals.rb
+++ b/db/migrate/20210920092648_change_datatype_images_of_seals.rb
@@ -1,5 +1,5 @@
 class ChangeDatatypeImagesOfSeals < ActiveRecord::Migration[6.1]
   def change
-    change_column :seals, :images, 'json USING CAST(images AS json)'
+    change_column :seals, :images, "json USING CAST(images AS json)"
   end
 end

--- a/db/migrate/20210920092648_change_datatype_images_of_seals.rb
+++ b/db/migrate/20210920092648_change_datatype_images_of_seals.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeImagesOfSeals < ActiveRecord::Migration[6.1]
+  def change
+    change_column :seals, :images, 'json USING CAST(images AS json)'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_18_130007) do
+ActiveRecord::Schema.define(version: 2021_09_20_092648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2021_09_18_130007) do
     t.string "title"
     t.string "place"
     t.date "date", null: false
-    t.string "image"
+    t.json "images"
     t.integer "likes_count", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 実装内容
issue #29  完了後に行う

  - `rails g uploader Seal_image` を実行し、ファイルを作成

### DB
 -  sealsテーブルのimagesカラムのデータ型を`json`に変更 

### コントローラ
  - コントローラで画像を受け取るパラメーターを追加

### ビュー
  - 新規投稿ページと編集ページのフォームに `<%= form.file_field :images %>` を加える
    - 複数画像選択ができるように、`multiple: true `を追記
  - 画像がないときにエラーが出ないよう条件分岐させる
  - 画像を削除できるように、チェックボックスを追記

### モデル
  - `seal`テーブル と `users`テーブル の `images`カラム に `seal_image_uploader.rb` のクラス `SealImageUploader`とリレーションさせる

### バリデーション設定

## チェックリスト
- [x] 各動作確認
- [x] rubocop -a を実行
- [x] bundle exec rails_best_practices .  を実行 