### PR TITLE
form 都道府県表示の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.7.3"
 
+gem "active_hash"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "carrierwave", "~> 2.0"
 gem "devise"
@@ -16,7 +17,6 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
-gem 'active_hash'
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "rails-i18n", "~> 6.0"
 gem "sass-rails", ">= 6"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 5.0"
+gem 'active_hash'
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.1.4)
       activesupport (= 6.1.4)
       globalid (>= 0.3.6)
@@ -269,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.4)
   byebug
   carrierwave (~> 2.0)

--- a/app/controllers/seals_controller.rb
+++ b/app/controllers/seals_controller.rb
@@ -34,7 +34,7 @@ class SealsController < ApplicationController
   private
 
   def seal_params
-    params.require(:seal).permit(:category, :title, :place, :date, { images: [] })
+    params.require(:seal).permit(:category, :prefecture_id, :place, :date, { images: [] })
   end
 
   def set_seal

--- a/app/controllers/worships_controller.rb
+++ b/app/controllers/worships_controller.rb
@@ -35,7 +35,7 @@ class WorshipsController < ApplicationController
   private
 
   def worship_params
-    params.require(:worship).permit(:category, :title, :place, :date, :content, { images: [] }, :images_cache, :remove_images)
+    params.require(:worship).permit(:category, :prefecture_id, :place, :date, :content, { images: [] }, :images_cache, :remove_images)
   end
 
   def set_worship

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,23 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    { id: 1, name: "北海道" }, { id: 2, name: "青森県" }, { id: 3, name: "岩手県" },
+    { id: 4, name: "宮城県" }, { id: 5, name: "秋田県" }, { id: 6, name: "山形県" },
+    { id: 7, name: "福島県" }, { id: 8, name: "茨城県" }, { id: 9, name: "栃木県" },
+    { id: 10, name: "群馬県" }, { id: 11, name: "埼玉県" }, { id: 12, name: "千葉県" },
+    { id: 13, name: "東京都" }, { id: 14, name: "神奈川県" }, { id: 15, name: "新潟県" },
+    { id: 16, name: "富山県" }, { id: 17, name: "石川県" }, { id: 18, name: "福井県" },
+    { id: 19, name: "山梨県" }, { id: 20, name: "長野県" }, { id: 21, name: "岐阜県" },
+    { id: 22, name: "静岡県" }, { id: 23, name: "愛知県" }, { id: 24, name: "三重県" },
+    { id: 25, name: "滋賀県" }, { id: 26, name: "京都府" }, { id: 27, name: "大阪府" },
+    { id: 28, name: "兵庫県" }, { id: 29, name: "奈良県" }, { id: 30, name: "和歌山県" },
+    { id: 31, name: "鳥取県" }, { id: 32, name: "島根県" }, { id: 33, name: "岡山県" },
+    { id: 34, name: "広島県" }, { id: 35, name: "山口県" }, { id: 36, name: "徳島県" },
+    { id: 37, name: "香川県" }, { id: 38, name: "愛媛県" }, { id: 39, name: "高知県" },
+    { id: 40, name: "福岡県" }, { id: 41, name: "佐賀県" }, { id: 42, name: "長崎県" },
+    { id: 43, name: "熊本県" }, { id: 44, name: "大分県" }, { id: 45, name: "宮崎県" },
+    { id: 46, name: "鹿児島県" }, { id: 47, name: "沖縄県" }
+  ]
+
+  include ActiveHash::Associations
+  has_many :worships
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -20,4 +20,5 @@ class Prefecture < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :worships
+  has_many :seals
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -19,6 +19,6 @@ class Prefecture < ActiveHash::Base
   ]
 
   include ActiveHash::Associations
-  has_many :worships
-  has_many :seals
+  has_many :worships, dependent: :destroy
+  has_many :seals, dependent: :destroy
 end

--- a/app/models/seal.rb
+++ b/app/models/seal.rb
@@ -10,4 +10,7 @@ class Seal < ApplicationRecord
   def liked_seal_by?(user)
     seal_likes.any? { |seal_like| seal_like.user_id == user.id }
   end
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/models/worship.rb
+++ b/app/models/worship.rb
@@ -11,4 +11,7 @@ class Worship < ApplicationRecord
   def liked_worship_by?(user)
     worship_likes.any? { |worship_like| worship_like.user_id == user.id }
   end
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
 end

--- a/app/views/seals/_form.html.erb
+++ b/app/views/seals/_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with model: @seal, local: true do |f| %>
   <p><%= f.label :category, "寺社を選択" %></p>
   <p><%= f.select :category, [["神社", "神社"],["寺", "寺"]], include_blank: "選択して下さい" %></p>
-  <p><%= f.label :title, "タイトル" %></p>
-  <p><%= f.text_field :title %></p>
+  <p><%= f.label :prefecture, "都道府県" %></p>
+  <p><%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: ""} %></p>
   <p><%= f.label :place, "場所" %></p>
   <p><%= f.text_field :place %></p>
   <p><%= f.label :date, "参拝日" %></p>

--- a/app/views/seals/_seal.html.erb
+++ b/app/views/seals/_seal.html.erb
@@ -14,8 +14,8 @@
                   <p><%= image_tag "default.jpg", class: 'card-img-top' %></p>
                 <% end %>
                 <div class="card-body">
-                  <p class="card-text"><%= seal.category %> | <%= seal.place %></p>
-                  <p class="card-text"><%= seal.title %></p>
+                  <p class="card-text"><%= seal.category %> | <%= seal.prefecture.name %></p>
+                  <p class="card-text"><%= seal.place %></p>
                   <p class="card-text"><%= seal.user_name.present? ? seal.user_name : "会員No.#{seal.user.id}" %></p>
                 </div>
               </a>

--- a/app/views/seals/index.html.erb
+++ b/app/views/seals/index.html.erb
@@ -10,8 +10,8 @@
                 <% if seal.images? %>
                   <p><%= image_tag seal.images[0].to_s, class: 'card-img-top' %></p>
                 <% end %>
-                <p><%= seal.category %> | <%= seal.place %></p>
-                <p><%= seal.title %></p>
+                <p><%= seal.category %> | <%= seal.prefecture.name %></p>
+                <p><%= seal.place %></p>
                 <p><%= seal.user_name.present? ? seal.user_name : "会員No.#{seal.user.id}" %></p>
                 <p id="seal-<%= seal.id %>">
                   <% if seal.liked_seal_by?(current_user) %>

--- a/app/views/seals/show.html.erb
+++ b/app/views/seals/show.html.erb
@@ -5,7 +5,7 @@
   <% end %>
 <% end %>
 <p><%= @seal.category %></p>
-<p><%= @seal.title %></p>
+<p><%= @seal.prefecture.name %></p>
 <p>場所 : <%= @seal.place %></p>
 <p>参拝日 : <%= @seal.date %></p>
 <% if @seal.user_name.present? %>

--- a/app/views/worships/_form.html.erb
+++ b/app/views/worships/_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with model: @worship, local: true do |f| %>
   <p><%= f.label :category, "寺社を選択" %></p>
   <p><%= f.select :category, [["神社", "神社"],["寺", "寺"]], include_blank: "選択して下さい" %></p>
-  <p><%= f.label :title, "タイトル" %></p>
-  <p><%= f.text_field :title %></p>
+  <p><%= f.label :prefecture_id, "都道府県" %></p>
+  <p><%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {include_blank: "---"}, {class: ""} %></p>
   <p><%= f.label :place, "場所" %></p>
   <p><%= f.text_field :place %></p>
   <p><%= f.label :date, "参拝日" %></p>

--- a/app/views/worships/_worship.html.erb
+++ b/app/views/worships/_worship.html.erb
@@ -15,8 +15,8 @@
                     <%= image_tag "default.jpg", class: 'card-img-top' %>
                   <% end %>
                   <div class="card-body">
-                    <p class="card-text"><%= worship.category %> | <%= worship.place %></p>
-                    <p class="card-text"><%= worship.title %></p>
+                    <p class="card-text"><%= worship.category %> | <%= worship.prefecture.name %> </p>
+                    <p class="card-text"><%= worship.place %></p>
                     <p class="card-text"><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
                   </div>
                 </a>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -10,8 +10,8 @@
                 <% if worship.images? %>
                   <p><%= image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
                 <% end %>
-                <p><%= worship.category %> | <%= worship.place %></p>
-                <p><%= worship.prefecture.name %></p>
+                <p><%= worship.category %> | <%= worship.prefecture.name %></p>
+                <p><%= worship.place %></p>
                 <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
                 <p id="worship-<%= worship.id %>">
                   <% if worship.liked_worship_by?(current_user) %>

--- a/app/views/worships/index.html.erb
+++ b/app/views/worships/index.html.erb
@@ -11,7 +11,7 @@
                   <p><%= image_tag worship.images[0].to_s, class: 'card-img-top' %></p>
                 <% end %>
                 <p><%= worship.category %> | <%= worship.place %></p>
-                <p><%= worship.title %></p>
+                <p><%= worship.prefecture.name %></p>
                 <p><%= worship.user_name.present? ? worship.user_name : "会員No.#{worship.user.id}" %></p>
                 <p id="worship-<%= worship.id %>">
                   <% if worship.liked_worship_by?(current_user) %>

--- a/app/views/worships/show.html.erb
+++ b/app/views/worships/show.html.erb
@@ -1,6 +1,6 @@
 <h1>参拝記事 詳細</h1>
 <p><%= @worship.category %></p>
-<p><%= @worship.title %></p>
+<p><%= @worship.prefecture.name %></p>
 <p>場所 : <%= @worship.place %></p>
 <p>参拝日 : <%= @worship.date %></p>
 <p><%= @worship.content %></p>

--- a/db/migrate/20211017071045_rename_title_column_to_worships.rb
+++ b/db/migrate/20211017071045_rename_title_column_to_worships.rb
@@ -1,0 +1,5 @@
+class RenameTitleColumnToWorships < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :worships, :title, :prefecture_id
+  end
+end

--- a/db/migrate/20211017071930_rename_title_column_to_seals.rb
+++ b/db/migrate/20211017071930_rename_title_column_to_seals.rb
@@ -1,0 +1,5 @@
+class RenameTitleColumnToSeals < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :seals, :title, :prefecture_id
+  end
+end

--- a/db/migrate/20211017080732_change_datatype_prefecture_id_of_worships.rb
+++ b/db/migrate/20211017080732_change_datatype_prefecture_id_of_worships.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypePrefectureIdOfWorships < ActiveRecord::Migration[6.1]
+  def change
+    change_column :worships, :prefecture_id, "integer USING CAST(prefecture_id AS integer)"
+  end
+end

--- a/db/migrate/20211017081043_change_datatype_prefecture_id_of_seals.rb
+++ b/db/migrate/20211017081043_change_datatype_prefecture_id_of_seals.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypePrefectureIdOfSeals < ActiveRecord::Migration[6.1]
+  def change
+    change_column :seals, :prefecture_id, "integer USING CAST(prefecture_id AS integer)"
+  end
+end

--- a/db/migrate/20211017082056_change_columns_add_notnull_on_worhips.rb
+++ b/db/migrate/20211017082056_change_columns_add_notnull_on_worhips.rb
@@ -1,0 +1,9 @@
+class ChangeColumnsAddNotnullOnWorhips < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :worships, :category, false
+    change_column_null :worships, :prefecture_id, false
+    change_column_null :worships, :place, false
+    change_column_null :worships, :content, false
+    change_column_null :worships, :date, false
+  end
+end

--- a/db/migrate/20211017083010_change_columns_add_notnull_on_seals.rb
+++ b/db/migrate/20211017083010_change_columns_add_notnull_on_seals.rb
@@ -1,0 +1,6 @@
+class ChangeColumnsAddNotnullOnSeals < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :seals, :prefecture_id, false
+    change_column_null :seals, :place, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_17_081043) do
+ActiveRecord::Schema.define(version: 2021_10_17_083010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,8 +47,8 @@ ActiveRecord::Schema.define(version: 2021_10_17_081043) do
 
   create_table "seals", force: :cascade do |t|
     t.string "category", null: false
-    t.integer "prefecture_id"
-    t.string "place"
+    t.integer "prefecture_id", null: false
+    t.string "place", null: false
     t.date "date", null: false
     t.json "images"
     t.integer "likes_count", default: 0
@@ -84,11 +84,11 @@ ActiveRecord::Schema.define(version: 2021_10_17_081043) do
   end
 
   create_table "worships", force: :cascade do |t|
-    t.string "category"
-    t.integer "prefecture_id"
-    t.string "place"
-    t.text "content"
-    t.date "date"
+    t.string "category", null: false
+    t.integer "prefecture_id", null: false
+    t.string "place", null: false
+    t.text "content", null: false
+    t.date "date", null: false
     t.json "images"
     t.float "rating"
     t.integer "likes_count", default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_03_093909) do
+ActiveRecord::Schema.define(version: 2021_10_17_081043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2021_10_03_093909) do
 
   create_table "seals", force: :cascade do |t|
     t.string "category", null: false
-    t.string "title"
+    t.integer "prefecture_id"
     t.string "place"
     t.date "date", null: false
     t.json "images"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2021_10_03_093909) do
 
   create_table "worships", force: :cascade do |t|
     t.string "category"
-    t.string "title"
+    t.integer "prefecture_id"
     t.string "place"
     t.text "content"
     t.date "date"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,31 +17,31 @@ user3 = User.create!(email: "tanaka@example.com", password: "password")
 
 puts "ユーザデータの投入に成功しました！"
 
-worship1 = user1.worships.create!(category: "寺", title: "浅草寺", place: "神奈川県寒川市", content: "いつも年末年始にお世話になっています", date: "2021/09/17")
-worship2 = user2.worships.create!(category: "神社", title: "諏訪神社", place: "長野県諏訪市", content: "見応えがあり、社ごとに雰囲気が違ってゆっくり楽しめた。", date: "2021/09/13")
-worship3 = user3.worships.create!(category: "寺", title: "常泉寺", place: "神奈川大和市", content: "彼岸花が咲き誇り、とても美しいお寺。河童さんが沢山いた！", date: "2021/09/08")
+# worship1 = user1.worships.create!(category: "寺", prefecture_id: "", place: "寒川神社", content: "いつも年末年始にお世話になっています", date: "2021/09/17")
+# worship2 = user2.worships.create!(category: "神社", prefecture_id: "", place: "諏訪大社", content: "見応えがあり、社ごとに雰囲気が違ってゆっくり楽しめた。", date: "2021/09/13")
+# worship3 = user3.worships.create!(category: "寺", prefecture_id: "", place: "常泉寺", content: "彼岸花が咲き誇り、とても美しいお寺。河童さんが沢山いた！", date: "2021/09/08")
 
-puts "worshipsデータの投入に成功しました！"
+# puts "worshipsデータの投入に成功しました！"
 
-seal1 = user1.seals.create!(category: "寺", title: "浅草寺", place: "神奈川県寒川市", date: "2021/09/17")
-seal2 = user2.seals.create!(category: "神社", title: "諏訪神社", place: "長野県諏訪市", date: "2021/09/13")
-seal3 = user3.seals.create!(category: "寺", title: "常泉寺", place: "神奈川大和市", date: "2021/09/08")
+# seal1 = user1.seals.create!(category: "寺", prefecture_id: "", place: "寒川神社", date: "2021/09/17")
+# seal2 = user2.seals.create!(category: "神社", prefecture_id: "", place: "諏訪大社", date: "2021/09/13")
+# seal3 = user3.seals.create!(category: "寺", prefecture_id: "", place: "常泉寺", date: "2021/09/08")
 
-puts "sealsデータの投入に成功しました！"
+# puts "sealsデータの投入に成功しました！"
 
-worship1.worship_likes.create!(user_id: user1.id)
-worship3.worship_likes.create!(user_id: user3.id)
-worship2.worship_likes.create!(user_id: user3.id)
-worship2.worship_likes.create!(user_id: user1.id)
+# worship1.worship_likes.create!(user_id: user1.id)
+# worship3.worship_likes.create!(user_id: user3.id)
+# worship2.worship_likes.create!(user_id: user3.id)
+# worship2.worship_likes.create!(user_id: user1.id)
 
-puts "worship_likeデータの投入に成功しました！"
+# puts "worship_likeデータの投入に成功しました！"
 
-seal1.seal_likes.create!(user_id: user1.id)
-seal3.seal_likes.create!(user_id: user3.id)
-seal2.seal_likes.create!(user_id: user3.id)
-seal2.seal_likes.create!(user_id: user1.id)
+# seal1.seal_likes.create!(user_id: user1.id)
+# seal3.seal_likes.create!(user_id: user3.id)
+# seal2.seal_likes.create!(user_id: user3.id)
+# seal2.seal_likes.create!(user_id: user1.id)
 
-puts "seal_likeデータの投入に成功しました！"
+# puts "seal_likeデータの投入に成功しました！"
 
 # ログイン時に使用するアカウント（変数への代入は不要）
 User.create!(email: email, password: password)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,31 +17,31 @@ user3 = User.create!(email: "tanaka@example.com", password: "password")
 
 puts "ユーザデータの投入に成功しました！"
 
-# worship1 = user1.worships.create!(category: "寺", prefecture_id: "", place: "寒川神社", content: "いつも年末年始にお世話になっています", date: "2021/09/17")
-# worship2 = user2.worships.create!(category: "神社", prefecture_id: "", place: "諏訪大社", content: "見応えがあり、社ごとに雰囲気が違ってゆっくり楽しめた。", date: "2021/09/13")
-# worship3 = user3.worships.create!(category: "寺", prefecture_id: "", place: "常泉寺", content: "彼岸花が咲き誇り、とても美しいお寺。河童さんが沢山いた！", date: "2021/09/08")
+worship1 = user1.worships.create!(category: "寺", prefecture_id: "14", place: "寒川神社", content: "いつも年末年始にお世話になっています", date: "2021/09/17")
+worship2 = user2.worships.create!(category: "神社", prefecture_id: "20", place: "諏訪大社", content: "見応えがあり、社ごとに雰囲気が違ってゆっくり楽しめた。", date: "2021/09/13")
+worship3 = user3.worships.create!(category: "寺", prefecture_id: "14", place: "常泉寺", content: "彼岸花が咲き誇り、とても美しいお寺。河童さんが沢山いた！", date: "2021/09/08")
 
-# puts "worshipsデータの投入に成功しました！"
+puts "worshipsデータの投入に成功しました！"
 
-# seal1 = user1.seals.create!(category: "寺", prefecture_id: "", place: "寒川神社", date: "2021/09/17")
-# seal2 = user2.seals.create!(category: "神社", prefecture_id: "", place: "諏訪大社", date: "2021/09/13")
-# seal3 = user3.seals.create!(category: "寺", prefecture_id: "", place: "常泉寺", date: "2021/09/08")
+seal1 = user1.seals.create!(category: "寺", prefecture_id: "14", place: "寒川神社", date: "2021/09/17")
+seal2 = user2.seals.create!(category: "神社", prefecture_id: "20", place: "諏訪大社", date: "2021/09/13")
+seal3 = user3.seals.create!(category: "寺", prefecture_id: "14", place: "常泉寺", date: "2021/09/08")
 
-# puts "sealsデータの投入に成功しました！"
+puts "sealsデータの投入に成功しました！"
 
-# worship1.worship_likes.create!(user_id: user1.id)
-# worship3.worship_likes.create!(user_id: user3.id)
-# worship2.worship_likes.create!(user_id: user3.id)
-# worship2.worship_likes.create!(user_id: user1.id)
+worship1.worship_likes.create!(user_id: user1.id)
+worship3.worship_likes.create!(user_id: user3.id)
+worship2.worship_likes.create!(user_id: user3.id)
+worship2.worship_likes.create!(user_id: user1.id)
 
-# puts "worship_likeデータの投入に成功しました！"
+puts "worship_likeデータの投入に成功しました！"
 
-# seal1.seal_likes.create!(user_id: user1.id)
-# seal3.seal_likes.create!(user_id: user3.id)
-# seal2.seal_likes.create!(user_id: user3.id)
-# seal2.seal_likes.create!(user_id: user1.id)
+seal1.seal_likes.create!(user_id: user1.id)
+seal3.seal_likes.create!(user_id: user3.id)
+seal2.seal_likes.create!(user_id: user3.id)
+seal2.seal_likes.create!(user_id: user1.id)
 
-# puts "seal_likeデータの投入に成功しました！"
+puts "seal_likeデータの投入に成功しました！"
 
 # ログイン時に使用するアカウント（変数への代入は不要）
 User.create!(email: email, password: password)


### PR DESCRIPTION
close #48 

## 実装内容

-  下記投稿記事のテーブルの`title`を `prefecture` に変更
- `active_hash`で47都道府県をプルダウンで実装
  - prefectureモデルの作成
  - 各記事のモデルにアソシエーションを設定
- `seeds.rb`を修正

## チェックリスト
- [x] 各動作確認
- [x] rubocop -a を実行
- [x] bundle exec rails_best_practices .  を実行 